### PR TITLE
Idempotent and service EnvironmentFile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .ansible
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ This role installs Caddy using xcaddy on Linux systems. It builds a custom Caddy
 
 ### Configuration
 
-| Variable                    | Default                | Description                                                         |
-| --------------------------- | ---------------------- | ------------------------------------------------------------------- |
-| `xcaddy_caddyfile_content`  | `""`                   | Raw Caddyfile content (mutually exclusive with template)            |
-| `xcaddy_caddyfile_template` | `""`                   | Path to Caddyfile Jinja2 template (mutually exclusive with content) |
-| `xcaddy_caddyfile_path`     | `/etc/caddy/Caddyfile` | Path where Caddyfile will be deployed                               |
-| `xcaddy_config_dir`         | `/etc/caddy`           | Caddy configuration directory                                       |
-| `xcaddy_data_dir`           | `/var/lib/caddy`       | Caddy data directory (certificates, etc.)                           |
+| Variable                          | Default                | Description                                                                                                                                                                                                                               |
+|-----------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `xcaddy_caddyfile_content`        | `""`                   | Raw Caddyfile content (mutually exclusive with template)                                                                                                                                                                                  |
+| `xcaddy_caddyfile_template`       | `""`                   | Path to Caddyfile Jinja2 template (mutually exclusive                                                                                                                                                                                     |
+| with content)                     |                        |                                                                                                                                                                                                                                           |
+| `xcaddy_caddyfile_path`           | `/etc/caddy/Caddyfile` | Path where Caddyfile will be deployed                                                                                                                                                                                                     |
+ | `xcaddy_service_envfile_template` | `""`                   | Path to Caddy [service EnvironmentFile](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html) Jinja2 template. The environment variables defined within may also be referenced in the Caddyfile (e.g. `{env.MYVAR}`) |
+ | `xcaddy_service_envfile_path`     | `/etc/caddy/.env`      | Path where the Caddy service `EnvironmentFile` will be deployed (will be chmod `0600` to protect secrets/passwords)                                                                                                                       |
+| `xcaddy_config_dir`               | `/etc/caddy`           | Caddy configuration directory                                                                                                                                                                                                             |
+| `xcaddy_data_dir`                 | `/var/lib/caddy`       | Caddy data directory (certificates, etc.)                                                                                                                                                                                                 |
 
 ### Service
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ xcaddy_config_dir: /etc/caddy
 # Path to the Caddyfile
 xcaddy_caddyfile_path: /etc/caddy/Caddyfile
 
+# Define environment variables for the Caddy systemd service
+xcaddy_service_envfile_template: ''
+xcaddy_service_envfile_path: "{{ xcaddy_config_dir }}/.env"
+
 # Directory for Caddy data (certificates, etc.)
 xcaddy_data_dir: /var/lib/caddy
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,12 @@
 ---
 - name: Validate Caddy config
   ansible.builtin.command:
-    cmd: "{{ xcaddy_bin_path }} validate --config {{ xcaddy_caddyfile_path }}"
+    cmd: >- 
+      {{ xcaddy_bin_path }} 
+      {% if xcaddy_service_envfile_template | default('') | length > 0 %}
+      --envfile {{ xcaddy_service_envfile_path }}
+      {% endif %}
+      validate --config {{ xcaddy_caddyfile_path }}
   become: true
   changed_when: false
   listen: Reload Caddy

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,6 +35,11 @@
     mode: "0750"
   become: true
 
+- name: Ensure only one xcaddy_caddyfile variable is set
+  ansible.builtin.fail:
+    msg: "Both xcaddy_caddyfile_content and xcaddy_caddyfile_template cannot be set."
+  when: xcaddy_caddyfile_content | length > 0 and xcaddy_caddyfile_template | length > 0
+
 - name: Deploy Caddyfile from content
   ansible.builtin.copy:
     content: "{{ xcaddy_caddyfile_content }}"
@@ -43,8 +48,9 @@
     group: "{{ xcaddy_group }}"
     mode: "0644"
   become: true
+  register: xcaddy_caddyfile_result
   when: xcaddy_caddyfile_content | length > 0
-  notify: Reload Caddy
+  notify: Validate Caddy config
 
 - name: Deploy Caddyfile from template
   ansible.builtin.template:
@@ -54,5 +60,6 @@
     group: "{{ xcaddy_group }}"
     mode: "0644"
   become: true
+  register: xcaddy_caddyfile_result
   when: xcaddy_caddyfile_template | length > 0
-  notify: Reload Caddy
+  notify: Validate Caddy config

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,17 +1,36 @@
 ---
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
+- name: "Record if Caddy service is running"
+  ansible.builtin.set_fact:
+    xcaddy_service_running: >-
+      {{
+        ansible_facts.services['caddy.service'] is defined and
+        ansible_facts.services['caddy.service'].state == 'running'
+      }}
+
+- name: "Deploy Caddy service EnvironmentFile"
+  ansible.builtin.template:
+    src: "{{ xcaddy_service_envfile_template }}"
+    dest: "{{ xcaddy_service_envfile_path }}"
+    owner: "{{ xcaddy_user }}"
+    group: "{{ xcaddy_group }}"
+    mode: '0600' # should not be readable by anyone else (likely contains passwords/secrets)
+  when:
+    - xcaddy_service_envfile_template | default('') | length > 0
+    - xcaddy_service_envfile_path | default('') | length > 0
+  register: xcaddy_service_envfile_result
+  become: true
+
 - name: Deploy Caddy systemd service unit
   ansible.builtin.template:
     src: caddy.service.j2
     dest: /etc/systemd/system/caddy.service
     owner: root
     group: root
-    mode: "0644"
-  become: true
-  notify: Restart Caddy
-
-- name: Reload systemd daemon
-  ansible.builtin.systemd_service:
-    daemon_reload: true
+    mode: '0644'
+  register: xcaddy_service_result
   become: true
 
 - name: Enable Caddy service
@@ -20,9 +39,28 @@
     enabled: "{{ xcaddy_service_enabled }}"
   become: true
 
-- name: Start Caddy service
+- name: Reload systemd daemon if service unit changed
   ansible.builtin.systemd_service:
-    name: caddy
-    state: started
+    daemon_reload: true
+  when: xcaddy_service_result.changed
   become: true
+
+- name: "Record Caddy restart target"
+  ansible.builtin.set_fact:
+    xcaddy_service_restart: >-
+      {{
+        xcaddy_service_running and
+        (xcaddy_service_result.changed or
+        (xcaddy_service_envfile_result is defined and xcaddy_service_envfile_result.changed))
+      }}
+
+- name: "Record Caddy reload target"
+  ansible.builtin.set_fact:
+    xcaddy_service_reload: "{{ xcaddy_service_running and xcaddy_caddyfile_result.changed }}"
+
+- name: "Start or reload Caddy"
+  ansible.builtin.systemd:
+    name: caddy
+    state: "{{ 'restarted' if xcaddy_service_restart else ('reloaded' if xcaddy_service_reload else 'started') }}"
   when: xcaddy_service_started
+  become: true

--- a/templates/caddy.service.j2
+++ b/templates/caddy.service.j2
@@ -24,6 +24,9 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 RuntimeDirectory=caddy
 RuntimeDirectoryMode=0750
+{% if xcaddy_service_envfile_template | default('') | length > 0 %}
+EnvironmentFile={{ xcaddy_service_envfile_path }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Ensured role is idempotent across multiple runs (was previously forcing a reload or restart even if nothing changed)
- Ensured caddy systemd service can support an optional EnvironmentFile to set environment variables for the caddy process