### PR TITLE
Add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+---
+name: Claude
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    name: Run Claude
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Wires up `anthropics/claude-code-action@v1` to respond to `@claude` mentions in issues, PR comments, PR review comments, and PR review bodies.
- Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` so calls are billed against my Claude subscription rather than a per-token API key.

## Test plan
- [ ] After merge, comment `@claude say hi` on an issue or PR and confirm the workflow runs and replies.
- [ ] Confirm secret `CLAUDE_CODE_OAUTH_TOKEN` is present under repo Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)