### PR TITLE
Idempotent service handling and optional EnvironmentFile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This role installs Caddy using xcaddy on Linux systems. It builds a custom Caddy
 - **Idempotent builds** - only rebuilds when Caddy version or modules change
 - **Caddyfile configuration** - supports both raw content and Jinja2 templates
 - **Systemd integration** with proper capabilities for binding to privileged ports
+- **Optional `EnvironmentFile`** to pass environment variables to the Caddy process
+- **Fully idempotent** - converges cleanly with no spurious reloads or restarts
 - **Config validation** before reloading to prevent broken deployments
 - **Multi-distro support** - consistent Go-based installation across all supported distros
 
@@ -46,12 +48,14 @@ This role installs Caddy using xcaddy on Linux systems. It builds a custom Caddy
 
 ### Service
 
-| Variable                 | Default | Description                             |
-| ------------------------ | ------- | --------------------------------------- |
-| `xcaddy_service_enabled` | `true`  | Enable Caddy service at boot            |
-| `xcaddy_service_started` | `true`  | Start Caddy service after configuration |
-| `xcaddy_user`            | `caddy` | User to run Caddy service               |
-| `xcaddy_group`           | `caddy` | Group for Caddy service                 |
+| Variable                   | Default | Description                                                                                                  |
+| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `xcaddy_service_enabled`   | `true`  | Enable Caddy service at boot                                                                                 |
+| `xcaddy_service_started`   | `true`  | Start Caddy service after configuration                                                                      |
+| `xcaddy_user`              | `caddy` | User to run Caddy service                                                                                    |
+| `xcaddy_group`             | `caddy` | Group for Caddy service                                                                                      |
+| `xcaddy_environment_file`  | `""`    | Optional path for the systemd `EnvironmentFile=` directive (omitted when empty)                              |
+| `xcaddy_environment`       | `{}`    | Optional dict of environment variables; rendered to `xcaddy_environment_file` when both are set              |
 
 ### Paths
 
@@ -127,6 +131,31 @@ This role installs Caddy using xcaddy on Linux systems. It builds a custom Caddy
           }
 ```
 
+### With an Environment File (DNS provider credentials)
+
+Pass secrets to Caddy via a systemd `EnvironmentFile` instead of embedding them
+in the Caddyfile. The role renders `xcaddy_environment` to the file when both
+variables are set; omit `xcaddy_environment` to manage the file out of band.
+
+```yaml
+- hosts: webservers
+  roles:
+    - role: sebdanielsson.xcaddy
+      vars:
+        xcaddy_modules:
+          - github.com/caddy-dns/cloudflare
+        xcaddy_environment_file: /etc/caddy/caddy.env
+        xcaddy_environment:
+          CF_API_TOKEN: "{{ vault_cf_api_token }}"
+        xcaddy_caddyfile_content: |
+          example.com {
+            tls {
+              dns cloudflare {env.CF_API_TOKEN}
+            }
+            reverse_proxy localhost:8080
+          }
+```
+
 ### Uninstall Caddy
 
 ```yaml
@@ -155,7 +184,11 @@ The role includes the following handlers:
 
 - **Validate Caddy config**: Runs `caddy validate` before reload
 - **Reload Caddy**: Reloads Caddy configuration (triggered by Caddyfile changes)
-- **Restart Caddy**: Restarts Caddy service (triggered by binary changes)
+- **Reload systemd daemon**: Runs `systemctl daemon-reload` (triggered only when the unit file changes)
+- **Restart Caddy**: Restarts Caddy service (triggered by binary, unit file, or environment file changes)
+
+Handlers only fire when the resource they watch actually changes, so a converged
+host re-runs with zero changes and no service disruption.
 
 ## Contributing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,23 @@ xcaddy_service_started: true
 xcaddy_user: caddy
 xcaddy_group: caddy
 
+# Optional path to an environment file referenced by the systemd unit
+# (EnvironmentFile=). When set, the directive is added to caddy.service.
+# The reference is optional (prefixed with "-"), so a missing file does not
+# fail the service. Leave empty to omit the directive entirely.
+# Example:
+#   xcaddy_environment_file: /etc/caddy/caddy.env
+xcaddy_environment_file: ""
+
+# Optional environment variables for the Caddy process.
+# When non-empty AND xcaddy_environment_file is set, the role renders these
+# key/value pairs to xcaddy_environment_file. Leave empty to manage the
+# environment file out of band (e.g. with secrets from another source).
+# Example:
+#   xcaddy_environment:
+#     CF_API_TOKEN: "{{ vault_cf_api_token }}"
+xcaddy_environment: {}
+
 # Path to install the Caddy binary
 xcaddy_bin_path: /usr/local/bin/caddy
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,11 @@
     state: reloaded
   become: true
 
+- name: Reload systemd daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  become: true
+
 - name: Restart Caddy
   ansible.builtin.systemd_service:
     name: caddy

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,6 +11,9 @@
       :8080 {
         respond "OK"
       }
+    xcaddy_environment_file: /etc/caddy/caddy.env
+    xcaddy_environment:
+      CADDY_TEST_VAR: hello
   tasks:
     - name: Apply xcaddy role (initial build)
       ansible.builtin.include_role:
@@ -39,6 +42,9 @@
       :8080 {
         respond "OK"
       }
+    xcaddy_environment_file: /etc/caddy/caddy.env
+    xcaddy_environment:
+      CADDY_TEST_VAR: hello
   tasks:
     - name: Apply xcaddy role (idempotency check)
       ansible.builtin.include_role:
@@ -67,6 +73,9 @@
       :8080 {
         respond "OK"
       }
+    xcaddy_environment_file: /etc/caddy/caddy.env
+    xcaddy_environment:
+      CADDY_TEST_VAR: hello
   tasks:
     - name: Apply xcaddy role (version bump)
       ansible.builtin.include_role:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -129,7 +129,7 @@
       ansible.builtin.assert:
         that:
           - env_file.stat.exists
-          - "'CADDY_TEST_VAR=hello' in (env_file_content.content | b64decode)"
+          - "'CADDY_TEST_VAR=\"hello\"' in (env_file_content.content | default('') | b64decode)"
         fail_msg: "Environment file missing or does not contain the expected variable"
         success_msg: "Environment file exists and contains the expected variable"
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -101,6 +101,38 @@
         fail_msg: "Service file not found at /etc/systemd/system/caddy.service"
         success_msg: "Service file exists at /etc/systemd/system/caddy.service"
 
+    # Verify environment file and EnvironmentFile directive
+    - name: Read service unit file
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/caddy.service
+      register: service_file_content
+
+    - name: Assert EnvironmentFile directive is present
+      ansible.builtin.assert:
+        that:
+          - "'EnvironmentFile=-/etc/caddy/caddy.env' in (service_file_content.content | b64decode)"
+        fail_msg: "EnvironmentFile directive not found in caddy.service unit"
+        success_msg: "EnvironmentFile directive is present in caddy.service unit"
+
+    - name: Check environment file exists
+      ansible.builtin.stat:
+        path: /etc/caddy/caddy.env
+      register: env_file
+
+    - name: Read environment file
+      ansible.builtin.slurp:
+        src: /etc/caddy/caddy.env
+      register: env_file_content
+      when: env_file.stat.exists
+
+    - name: Assert environment file is rendered correctly
+      ansible.builtin.assert:
+        that:
+          - env_file.stat.exists
+          - "'CADDY_TEST_VAR=hello' in (env_file_content.content | b64decode)"
+        fail_msg: "Environment file missing or does not contain the expected variable"
+        success_msg: "Environment file exists and contains the expected variable"
+
     # Verify caddy user and group
     - name: Check caddy user exists
       ansible.builtin.getent:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,17 @@
 ---
+- name: Deploy Caddy environment file
+  ansible.builtin.template:
+    src: caddy.env.j2
+    dest: "{{ xcaddy_environment_file }}"
+    owner: "{{ xcaddy_user }}"
+    group: "{{ xcaddy_group }}"
+    mode: "0640"
+  become: true
+  when:
+    - xcaddy_environment_file | length > 0
+    - xcaddy_environment | length > 0
+  notify: Restart Caddy
+
 - name: Deploy Caddy systemd service unit
   ansible.builtin.template:
     src: caddy.service.j2
@@ -7,12 +20,9 @@
     group: root
     mode: "0644"
   become: true
-  notify: Restart Caddy
-
-- name: Reload systemd daemon
-  ansible.builtin.systemd_service:
-    daemon_reload: true
-  become: true
+  notify:
+    - Reload systemd daemon
+    - Restart Caddy
 
 - name: Enable Caddy service
   ansible.builtin.systemd_service:

--- a/templates/caddy.env.j2
+++ b/templates/caddy.env.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# Environment file for the Caddy systemd service
+# Referenced via EnvironmentFile= in caddy.service
+{% for key, value in xcaddy_environment | dictsort %}
+{{ key }}={{ value }}
+{% endfor %}

--- a/templates/caddy.env.j2
+++ b/templates/caddy.env.j2
@@ -2,5 +2,5 @@
 # Environment file for the Caddy systemd service
 # Referenced via EnvironmentFile= in caddy.service
 {% for key, value in xcaddy_environment | dictsort %}
-{{ key }}={{ value }}
+{{ key }}="{{ value | string | replace('\\', '\\\\') | replace('"', '\\"') }}"
 {% endfor %}

--- a/templates/caddy.service.j2
+++ b/templates/caddy.service.j2
@@ -12,6 +12,9 @@ Requires=network-online.target
 Type=notify
 User={{ xcaddy_user }}
 Group={{ xcaddy_group }}
+{% if xcaddy_environment_file | length > 0 %}
+EnvironmentFile=-{{ xcaddy_environment_file }}
+{% endif %}
 ExecStart={{ xcaddy_bin_path }} run --environ --config {{ xcaddy_caddyfile_path }}
 ExecReload={{ xcaddy_bin_path }} reload --config {{ xcaddy_caddyfile_path }}
 TimeoutStopSec=5s


### PR DESCRIPTION
## Summary

Implements two features (reworked from scratch, superseding #16):

1. **Full idempotency** of the systemd service tasks — a converged host now re-runs with zero changes and no spurious reloads/restarts.
2. **Optional `EnvironmentFile`** support so environment variables can be passed to the Caddy process.

## Idempotency

The root cause was the unconditional `daemon_reload: true` task in `tasks/service.yml`. The `systemd_service` module with `daemon_reload` alone *always* reports `changed`, so every run looked dirty and could trigger a restart.

- Moved it into a new **`Reload systemd daemon`** handler, notified only when the unit file changes.
- Ordered before `Restart Caddy` in `handlers/main.yml` so the daemon reload happens before any restart.

## EnvironmentFile

- `xcaddy_environment_file` (default `""`) — when set, renders `EnvironmentFile=-<path>` into the unit. The `-` prefix makes the reference optional, so a missing file does not fail the service.
- `xcaddy_environment` (default `{}`) — when set alongside the file path, the role renders the key/value pairs to the env file (mode `0640`) and restarts Caddy on change. Omit it to manage the file out of band (e.g. secrets from another source).

## Changes

- `tasks/service.yml` — handler-driven daemon reload; deploy env file when configured.
- `handlers/main.yml` — new `Reload systemd daemon` handler.
- `templates/caddy.service.j2` — conditional `EnvironmentFile=-` directive.
- `templates/caddy.env.j2` — new env file template.
- `defaults/main.yml` — new variables with documentation.
- `README.md` — variables, example playbook, handler notes.
- `molecule/default/{converge,verify}.yml` — coverage for the env file and directive.

## Testing

- `ansible-lint` passes at the **production** profile (0 failures, 0 warnings).
- `yamllint` clean (only pre-existing workflow warnings).
- Molecule converge/verify updated to assert the env file is rendered and the `EnvironmentFile` directive is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)