### PR TITLE
fix caddy validate when using envfile

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,14 @@
 ---
 - name: Validate Caddy config
   ansible.builtin.command:
-    cmd: "{{ xcaddy_bin_path }} validate --config {{ xcaddy_caddyfile_path }}"
+    argv: "{{ xcaddy_validate_argv_base + xcaddy_validate_envfile_argv }}"
+  vars:
+    xcaddy_validate_argv_base:
+      - "{{ xcaddy_bin_path }}"
+      - validate
+      - --config
+      - "{{ xcaddy_caddyfile_path }}"
+    xcaddy_validate_envfile_argv: "{{ ['--envfile', xcaddy_environment_file] if xcaddy_environment_file | length > 0 else [] }}"
   become: true
   changed_when: false
   listen: Reload Caddy


### PR DESCRIPTION
using an envfile with a newer version of caddy is broken. This should fix it


```
TASK [sebdanielsson.xcaddy : Uninstall Caddy] ************************************************
skipping: [xxxxx]

RUNNING HANDLER [sebdanielsson.xcaddy : Validate Caddy config] *******************************
[ERROR]: Task failed: Module failed: non-zero return code
Origin: /Users/mahamed/.ansible/roles/sebdanielsson.xcaddy/handlers/main.yml:2:3

1 ---
2 - name: Validate Caddy config
    ^ column 3

fatal: [xxxxx]: FAILED! => {"changed": false, "cmd": ["/usr/local/bin/caddy", "validate", "--config", "/etc/caddy/Caddyfile"], "delta": "0:00:00.031463", "end": "2026-06-17 12:29:30.820095", "msg": "non-zero return code", "rc": 1, "start": "2026-06-17 12:29:30.788632", "stderr": "{\"level\":\"info\",\"ts\":1781688570.816448,\"msg\":\"using config from file\",\"file\":\"/etc/caddy/Caddyfile\"}\n{\"level\":\"info\",\"ts\":1781688570.8182082,\"msg\":\"adapted config to JSON\",\"adapter\":\"caddyfile\"}\n{\"level\":\"warn\",\"ts\":1781688570.8182485,\"msg\":\"Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies\",\"adapter\":\"caddyfile\",\"file\":\"/etc/caddy/Caddyfile\",\"line\":2}\n{\"level\":\"info\",\"ts\":1781688570.8186467,\"logger\":\"tls.cache.maintenance\",\"msg\":\"started background certificate maintenance\",\"cache\":\"0x3bd778c7fd80\"}\n{\"level\":\"info\",\"ts\":1781688570.8186622,\"logger\":\"tls.cache.maintenance\",\"msg\":\"stopped background certificate maintenance\",\"cache\":\"0x3bd778c7fd80\"}\n{\"level\":\"info\",\"ts\":1781688570.8186882,\"logger\":\"http\",\"msg\":\"servers shutting down with eternal grace period\"}\nError: loading http app module: provision http: getting tls app: loading tls app module: provision tls: provisioning automation policy 0: loading TLS automation management module: position 0: loading module 'acme': provision tls.issuance.acme: loading DNS provider module: loading module 'cloudflare': provision dns.providers.cloudflare: API token '' appears invalid; ensure it's correctly entered and not wrapped in braces nor quotes", "stderr_lines": ["{\"level\":\"info\",\"ts\":1781688570.816448,\"msg\":\"using config from file\",\"file\":\"/etc/caddy/Caddyfile\"}", "{\"level\":\"info\",\"ts\":1781688570.8182082,\"msg\":\"adapted config to JSON\",\"adapter\":\"caddyfile\"}", "{\"level\":\"warn\",\"ts\":1781688570.8182485,\"msg\":\"Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies\",\"adapter\":\"caddyfile\",\"file\":\"/etc/caddy/Caddyfile\",\"line\":2}", "{\"level\":\"info\",\"ts\":1781688570.8186467,\"logger\":\"tls.cache.maintenance\",\"msg\":\"started background certificate maintenance\",\"cache\":\"0x3bd778c7fd80\"}", "{\"level\":\"info\",\"ts\":1781688570.8186622,\"logger\":\"tls.cache.maintenance\",\"msg\":\"stopped background certificate maintenance\",\"cache\":\"0x3bd778c7fd80\"}", "{\"level\":\"info\",\"ts\":1781688570.8186882,\"logger\":\"http\",\"msg\":\"servers shutting down with eternal grace period\"}", "Error: loading http app module: provision http: getting tls app: loading tls app module: provision tls: provisioning automation policy 0: loading TLS automation management module: position 0: loading module 'acme': provision tls.issuance.acme: loading DNS provider module: loading module 'cloudflare': provision dns.providers.cloudflare: API token '' appears invalid; ensure it's correctly entered and not wrapped in braces nor quotes"], "stdout": "", "stdout_lines": []}
```